### PR TITLE
Respect .skip and .only

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,20 +2,28 @@ var CompositeDisposable = require('atom').CompositeDisposable
 
 var POSSIBLE_PREFIXES = [
   'it(',
+  'it.skip(',
+  'it.only(',
   'beforeEach(',
   'afterEach(',
   'before(',
   'after(',
 
   'it (',
+  'it.skip (',
+  'it.only (',
   'beforeEach (',
   'afterEach (',
   'before (',
   'after (',
 
   'it "',
+  'it.skip "',
+  'it.only "',
   'it \'',
-  
+  'it.skip \'',
+  'it.only \'',
+
   'beforeEach ->',
   'afterEach ->',
   'before ->',


### PR DESCRIPTION
One may skip test cases or execute only a single one. This is done by calling `it.skip` or `it.only` instead of plain `it`. I added the respective prefixes such that these `it`-Blocks should be folded by the plugin as well.

The additions are not tested in any way as they seem to be very straightforward.
